### PR TITLE
fix project builder log selection color

### DIFF
--- a/Framework/PCProjectBuilder.m
+++ b/Framework/PCProjectBuilder.m
@@ -220,6 +220,11 @@
   [logOutput setSelectable:YES];
   [logOutput setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
   [logOutput setBackgroundColor:[NSColor lightGrayColor]];
+  [logOutput setSelectedTextAttributes:
+    [NSDictionary dictionaryWithObjectsAndKeys:
+      [NSColor whiteColor], NSBackgroundColorAttributeName,
+      [NSColor blackColor], NSForegroundColorAttributeName,
+      nil]];
   [[logOutput textContainer] setWidthTracksTextView:YES];
   [[logOutput textContainer] setHeightTracksTextView:YES];
   [logOutput setHorizontallyResizable:NO];


### PR DESCRIPTION
Selected text in the log is "invisible" right now because the selection color is that same as the color of NSTextView (lightGray). 