### PR TITLE
prevent external file from being open on first selection

### DIFF
--- a/Framework/PCEditorManager.m
+++ b/Framework/PCEditorManager.m
@@ -203,8 +203,8 @@ NSString *PCEditorDidResignActiveNotification =
       app = [[NSWorkspace sharedWorkspace] getBestAppInRole:@"Editor" forExtension:[fileName pathExtension]];
       if (app)
         {
-          if ([[NSWorkspace sharedWorkspace] openFile: filePath])
-            return nil;
+          /* yes, we've got an editor, but do not open it yet */
+          return nil;
         }
     }
 


### PR DESCRIPTION
If you select an external file (e.g. gorm) in the project file browser, it will open right away.
This behavior is problematic because sometimes you do not want to open the file.
For example, you want to remove it or drag the 'proxy-file-icon-thingy' to an editor/terminal/etc.

I changed the behavior so that you have to double click it in order to open it.
This is consistent with the way Workspace works (double click to open).
BTW: Open/NextSTEP works this way as well.