### PR TITLE
focus window after project file has been reopened

### DIFF
--- a/Framework/PCProjectManager.m
+++ b/Framework/PCProjectManager.m
@@ -707,6 +707,8 @@ NSString *PCActiveProjectDidChangeNotification = @"PCActiveProjectDidChange";
       [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL: [NSURL fileURLWithPath:projectPathToSave]];
     }
 
+  if (flag)
+    [self setActiveProject: project];
   
   return project;
 }


### PR DESCRIPTION
When reopening project, the current implementation does not make the project active.
This means that makeKeyAndOrderFront will be sent to wrong window.