### PR TITLE
* save files graciously taking into account there are modifications p…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2021-02-03 Riccardo Mottola <rm@gnu.org>
+
+	* Framework/PCProjectInspector.m
+	Check for invalid filenames and in case, reset to the original
+	file name.
+
+2021-02-03 Riccardo Mottola <rm@gnu.org>
+
+	* Framework/PCEditorManager.m:
+	Do not open an external editor if an in-window is requested.
+
 2020-09-08 Riccardo Mottola <rm@gnu.org>
 
 	* Modules/Editors/ProjectCenter/SyntaxHighlighter.h

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-02-04 Riccardo Mottola <rm@gnu.org>
+
+	* Framework/PCProjectManager.m
+	* PCAppController.m:
+	Cleanup a bit the setting of the active project and the key win.
+
 2021-02-03 Riccardo Mottola <rm@gnu.org>
 
 	* Framework/PCProjectInspector.m
@@ -7,12 +13,14 @@
 2021-02-03 Riccardo Mottola <rm@gnu.org>
 
 	* Framework/PCEditorManager.m:
+
 	Do not open an external editor if an in-window is requested.
 
 2020-09-08 Riccardo Mottola <rm@gnu.org>
 
 	* Modules/Editors/ProjectCenter/SyntaxHighlighter.h
 	* Modules/Editors/ProjectCenter/SyntaxHighlighter.m
+
 	Add setters for fonts.
 
 	* Modules/Editors/ProjectCenter/PCEditorView.h

--- a/Framework/PCEditorManager.m
+++ b/Framework/PCEditorManager.m
@@ -210,7 +210,6 @@ NSString *PCEditorDidResignActiveNotification =
           if ([[NSWorkspace sharedWorkspace] openFile: filePath])
             return nil;
         }
-      return nil;
     }
 
 //  NSLog(@"EditorManager 1: %@", _editorsDict);

--- a/Framework/PCEditorManager.m
+++ b/Framework/PCEditorManager.m
@@ -170,7 +170,7 @@ NSString *PCEditorDidResignActiveNotification =
   id<CodeParser>  parser;
   BOOL exists = [fm fileExistsAtPath:filePath isDirectory:&isDir];
 
-  // Determine if file not exist or file is directory
+  // Determine if file does not exist or file is directory
   if (!exists)
     {
       NSRunAlertPanel(@"Open Editor",
@@ -198,14 +198,19 @@ NSString *PCEditorDidResignActiveNotification =
   else
     {
       NSString *app;
+
+      /* we don't have in-window editors for any bundles right now */
+      if (!windowed)
+        return nil;
       
-      /* Check for bundles and if possible let them be opened by Workspace */
+      /* Check for bundles and if possible let them be opened by Workspace but only if windowed */
       app = [[NSWorkspace sharedWorkspace] getBestAppInRole:@"Editor" forExtension:[fileName pathExtension]];
-      if (app)
+      if (windowed && app != nil)
         {
           if ([[NSWorkspace sharedWorkspace] openFile: filePath])
             return nil;
         }
+      return nil;
     }
 
 //  NSLog(@"EditorManager 1: %@", _editorsDict);

--- a/Framework/PCProjectBuilder.m
+++ b/Framework/PCProjectBuilder.m
@@ -220,6 +220,11 @@
   [logOutput setSelectable:YES];
   [logOutput setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
   [logOutput setBackgroundColor:[NSColor lightGrayColor]];
+  [logOutput setSelectedTextAttributes:
+    [NSDictionary dictionaryWithObjectsAndKeys:
+      [NSColor whiteColor], NSBackgroundColorAttributeName,
+      [NSColor blackColor], NSForegroundColorAttributeName,
+      nil]];
   [[logOutput textContainer] setWidthTracksTextView:YES];
   [[logOutput textContainer] setHeightTracksTextView:YES];
   [logOutput setHorizontallyResizable:NO];

--- a/Framework/PCProjectEditor.m
+++ b/Framework/PCProjectEditor.m
@@ -215,6 +215,7 @@
   editor = [self openEditorForFile:filePath 
 			  editable:editable 
 			  windowed:windowed];
+  
   if (!editor)
     {
       NSLog(@"We don't have editor for file: %@", fileName);

--- a/Framework/PCProjectInspector.m
+++ b/Framework/PCProjectInspector.m
@@ -1,7 +1,7 @@
 /*
    GNUstep ProjectCenter - http://www.gnustep.org/experience/ProjectCenter.html
 
-   Copyright (C) 2000-2010 Free Software Foundation
+   Copyright (C) 2000-2021 Free Software Foundation
 
    Authors: Philippe C.D. Robert
             Serg Stoyan
@@ -977,9 +977,19 @@
 
 - (void)fileNameDidChange:(id)sender
 {
-  if ([fileName isEqualToString:[fileNameField stringValue]])
+  NSString *newName;
+
+  newName = [fileNameField stringValue];
+  if ([fileName isEqualToString:newName])
     {
+      [fileNameField setStringValue:fileName];
       return;
+    }
+  if ([[newName stringByTrimmingCharactersInSet:
+                [NSCharacterSet whitespaceAndNewlineCharacterSet]] length] == 0)
+    {
+      [fileNameField setStringValue:fileName];
+      return NO;
     }
 
 /*  PCLogInfo(self, @"{%@} file name changed from: %@ to: %@",

--- a/Framework/PCProjectManager.m
+++ b/Framework/PCProjectManager.m
@@ -1,7 +1,7 @@
 /*
    GNUstep ProjectCenter - http://www.gnustep.org/experience/ProjectCenter.html
 
-   Copyright (C) 2000-2017 Free Software Foundation
+   Copyright (C) 2000-2021 Free Software Foundation
 
    Authors: Philippe C.D. Robert
             Serg Stoyan
@@ -552,7 +552,6 @@ NSString *PCActiveProjectDidChangeNotification = @"PCActiveProjectDidChange";
   NSString     *projectPath = nil;
   NSString     *projectFileType = nil;
   PCProject    *project = nil;
-  NSDictionary *wap = nil;
   NSString     *projectPathToSave;
 
   // Check project path for invalid characters
@@ -675,14 +674,13 @@ NSString *PCActiveProjectDidChangeNotification = @"PCActiveProjectDidChange";
       [self startSaveTimer];
       [project validateProjectDict];
       
-      if (!project) 
-	{
-	  return nil;
-	}
-      
       [loadedProjects setObject:project forKey:[project projectPath]];
+      [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL: [NSURL fileURLWithPath:projectPathToSave]];
+      PCLogStatus(self, @"Saved opened Document as %@", projectPathToSave);
+
       if (flag)
 	{
+          NSDictionary *wap = nil;
 	  [project setProjectManager:self];
 	  
 	  // Windows and panels
@@ -699,14 +697,17 @@ NSString *PCActiveProjectDidChangeNotification = @"PCActiveProjectDidChange";
 	    {
 	      [[project projectWindow] showProjectLoadedFiles:self];
 	    }
-	  
-	  [[project projectWindow] makeKeyAndOrderFront:self];
-	  [self setActiveProject: project];
 	}
-      PCLogStatus(self, @"Saved opened Document as %@", projectPathToSave);
-      [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL: [NSURL fileURLWithPath:projectPathToSave]];
+    }
+  else
+    {
+      PCLogStatus(self, @"Project %@ already Open", [project projectName]);
     }
 
+  if (flag)
+    {
+      [self setActiveProject: project];
+    }
   
   return project;
 }

--- a/Framework/PCProjectWindow.m
+++ b/Framework/PCProjectWindow.m
@@ -658,8 +658,9 @@
 
 - (void)makeKeyAndOrderFront:(id)sender
 {
-//  PCLogInfo(self, @"makeKeyAndOrderFront sender: %@", [sender className]);
-  [projectWindow makeKeyAndOrderFront:nil];
+//  PCLogInfo(self, @"makeKeyAndOrderFront % @ sender: %@", [projectWindow title], [sender className]);
+//  NSLog(@"makeKeyAndOrderFront %@ sender: %@", [projectWindow title], [sender className]);
+  [projectWindow makeKeyAndOrderFront:self];
 }
 
 - (void)makeKeyWindow

--- a/Modules/Editors/ProjectCenter/PCEditor.m
+++ b/Modules/Editors/ProjectCenter/PCEditor.m
@@ -4,7 +4,7 @@
    Copyright (C) 2002-2015 Free Software Foundation
 
    Authors: Philippe C.D. Robert
-            Serg Stoyan
+	    Serg Stoyan
 	    Riccardo Mottola
 
    This file is part of GNUstep.
@@ -42,9 +42,9 @@
 //  PCLogInfo(self, @"[_createWindow]");
 
   style = NSTitledWindowMask
-        | NSClosableWindowMask
-        | NSMiniaturizableWindowMask
-        | NSResizableWindowMask;
+	| NSClosableWindowMask
+	| NSMiniaturizableWindowMask
+	| NSResizableWindowMask;
 
 
   windowWidth = [[NSFont userFixedPitchFontOfSize:0.0] widthOfString:@"A"];
@@ -61,7 +61,7 @@
   [_window setDelegate:self];
   [_window center];
   rect = [[_window contentView] frame];
-  
+
   // Scroll view
   _extScrollView = [[NSScrollView alloc] initWithFrame:rect];
   [_extScrollView setHasHorizontalScroller:NO];
@@ -156,7 +156,7 @@
   [ev setAllowsUndo: YES];
 
   [[NSNotificationCenter defaultCenter]
-    addObserver:self 
+    addObserver:self
        selector:@selector(textDidChange:)
 	   name:NSTextDidChangeNotification
 	 object:ev];
@@ -196,7 +196,7 @@
       ASSIGN(textColor, [NSColor blackColor]);
       ASSIGN(backgroundColor, [NSColor whiteColor]);
       ASSIGN(readOnlyColor, [NSColor lightGrayColor]);
-      
+
       previousFGColor = nil;
       previousBGColor = nil;
       previousFont = nil;
@@ -249,10 +249,10 @@
 // --- Protocol
 - (void)setParser:(id)parser
 {
-//  NSLog(@"RC aParser:%i parser:%i", 
+//  NSLog(@"RC aParser:%i parser:%i",
 //	[aParser retainCount], [parser retainCount]);
   ASSIGN(aParser, parser);
-//  NSLog(@"RC aParser:%i parser:%i", 
+//  NSLog(@"RC aParser:%i parser:%i",
 //	[aParser retainCount], [parser retainCount]);
 }
 
@@ -321,7 +321,7 @@
 }
 
 - (id)openExternalEditor:(NSString *)editor
-	 	withPath:(NSString *)file
+		withPath:(NSString *)file
 	   editorManager:(id)aDelegate
 {
   NSTask         *editorTask = nil;
@@ -345,22 +345,22 @@
   [[NSNotificationCenter defaultCenter]
     addObserver:self
        selector:@selector (externalEditorDidClose:)
-           name:NSTaskDidTerminateNotification
-         object:nil];
+	   name:NSTaskDidTerminateNotification
+	 object:nil];
 
   editorTask = [[NSTask alloc] init];
   [editorTask setLaunchPath:app];
   [args removeObjectAtIndex:0];
   [args addObject:file];
   [editorTask setArguments:args];
-  
+
   [editorTask launch];
 //  AUTORELEASE(editorTask);
 
   // Inform about file opening
   [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorDidOpenNotification
-                  object:self];
+		  object:self];
 
   return self;
 }
@@ -375,13 +375,13 @@
       NSLog(@"external editor task terminated");
       return;
     }
-    
+
   NSLog(@"Our Editor task terminated");
 
   // Inform about closing
-  [[NSNotificationCenter defaultCenter] 
+  [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorDidCloseNotification
-                  object:self];
+		  object:self];
 }
 
 // ===========================================================================
@@ -400,7 +400,7 @@
   return _window;
 }
 
-- (NSView *)editorView 
+- (NSView *)editorView
 {
   if (!_intScrollView)
     {
@@ -437,9 +437,9 @@
   _path = [path copy];
 
   // Post notification
-  [[NSNotificationCenter defaultCenter] 
+  [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorDidChangeFileNameNotification
-                  object:notifDict];
+		  object:notifDict];
 
   [notifDict autorelease];
 }
@@ -544,7 +544,7 @@
 //  NSDictionary   *method;
   NSDictionary   *class;
   NSMutableArray *items = [NSMutableArray array];
-  
+
   NSLog(@"PCEditor: asked for browser items for: %@", item);
 
   [aParser setString:[_storage string]];
@@ -634,7 +634,7 @@
     {
       return YES;
     }
-    
+
   [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorWillSaveNotification
 		  object:self];
@@ -648,13 +648,13 @@
     }
 
   saved = [[_storage string] writeToFile:_path atomically:YES];
- 
+
   if (saved == YES)
     {
       [self setIsEdited:NO];
       [[NSNotificationCenter defaultCenter]
 	postNotificationName:PCEditorDidSaveNotification
-	  	      object:self];
+		      object:self];
     }
   else
     {
@@ -710,11 +710,11 @@
 
   [_intEditorView setNeedsDisplay:YES];
   [_extEditorView setNeedsDisplay:YES];
-  
+
   [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorDidRevertNotification
 		  object:self];
-		  
+
   return YES;
 }
 
@@ -733,7 +733,7 @@
     }
 
   // Inform about closing
-  [[NSNotificationCenter defaultCenter] 
+  [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorDidCloseNotification
 		  object:self];
 
@@ -751,9 +751,9 @@
 	}
 
       // Inform about closing
-      [[NSNotificationCenter defaultCenter] 
+      [[NSNotificationCenter defaultCenter]
 	postNotificationName:PCEditorDidCloseNotification
-	              object:self];
+		      object:self];
 
       return YES;
     }
@@ -774,7 +774,7 @@
 
       ret = NSRunAlertPanel(@"Close File",
 			    @"File %@ has been modified. Save?",
-			    @"Save and Close", @"Don't save", @"Cancel", 
+			    @"Save and Close", @"Don't save", @"Cancel",
 			    [_path lastPathComponent]);
       switch (ret)
 	{
@@ -807,7 +807,7 @@
 {
   if ([sender isEqual:_window])
     {
-      if (_intScrollView) 
+      if (_intScrollView)
 	{
 	  // Just close if this file also displayed in int view
 	  _isWindowed = NO;
@@ -815,7 +815,7 @@
 	}
       else
 	{
-    	  return [self close:sender];
+	  return [self close:sender];
 	}
     }
 
@@ -864,7 +864,7 @@
 			  object:self];
 
 	  [self setIsEdited:YES];
-	  
+
 	  [[NSNotificationCenter defaultCenter]
 	    postNotificationName:PCEditorDidChangeNotification
 			  object:self];
@@ -908,7 +908,7 @@
 
 - (BOOL)becomeFirstResponder:(PCEditorView *)view
 {
-  [[NSNotificationCenter defaultCenter] 
+  [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorDidBecomeActiveNotification
 		  object:self];
 
@@ -917,7 +917,7 @@
 
 - (BOOL)resignFirstResponder:(PCEditorView *)view
 {
-  [[NSNotificationCenter defaultCenter] 
+  [[NSNotificationCenter defaultCenter]
     postNotificationName:PCEditorDidResignActiveNotification
 		  object:self];
 
@@ -962,7 +962,7 @@
     {
       if ([[class objectForKey:@"ClassName"] isEqualToString:className])
 	{
-	  classNameRange = 
+	  classNameRange =
 	    NSRangeFromString([class objectForKey:@"ClassNameRange"]);
 	  break;
 	}
@@ -990,7 +990,7 @@
     {
       if ([[method objectForKey:@"MethodName"] isEqualToString:methodName])
 	{
-	  methodNameRange = 
+	  methodNameRange =
 	    NSRangeFromString([method objectForKey:@"MethodNameRange"]);
 	  break;
 	}
@@ -1046,24 +1046,24 @@
   [task waitUntilExit];
   outString = [[[NSString alloc]
     initWithData: [[outPipe fileHandleForReading] availableData]
-        encoding: NSUTF8StringEncoding]
+	encoding: NSUTF8StringEncoding]
     autorelease];
   if ([task terminationStatus] != 0)
     {
       if (NSRunAlertPanel(_(@"Error running command"),
-        _(@"The command returned with a non-zero exit status"
-          @" -- aborting pipe.\n"
-          @"Do you want to see the command's output?\n"),
-        _(@"No"), _(@"Yes"), nil) == NSAlertAlternateReturn)
-        {
-          NSRunAlertPanel(_(@"The command's output"),
-            outString, nil, nil, nil);
-        }
+	_(@"The command returned with a non-zero exit status"
+	  @" -- aborting pipe.\n"
+	  @"Do you want to see the command's output?\n"),
+	_(@"No"), _(@"Yes"), nil) == NSAlertAlternateReturn)
+	{
+	  NSRunAlertPanel(_(@"The command's output"),
+	    outString, nil, nil, nil);
+	}
     }
   else
     {
       [_intEditorView replaceCharactersInRange:[_intEditorView selectedRange]
-                              withString:outString];
+			      withString:outString];
       [self textDidChange: nil];
     }
 }
@@ -1101,8 +1101,8 @@
  * to NO if it is located after the delimiter character.
  */
 static inline BOOL CheckDelimiter(unichar character,
-                                  unichar * oppositeDelimiter,
-                                  BOOL * searchBackwards)
+				  unichar * oppositeDelimiter,
+				  BOOL * searchBackwards)
 {
   if (character == '(')
     {
@@ -1166,10 +1166,10 @@ static inline BOOL CheckDelimiter(unichar character,
  *      if it isn't.
  */
 NSUInteger FindDelimiterInString(NSString * string,
-                                 unichar delimiter,
-                                 unichar oppositeDelimiter,
-                                 NSUInteger startLocation,
-                                 BOOL searchBackwards)
+				 unichar delimiter,
+				 unichar oppositeDelimiter,
+				 NSUInteger startLocation,
+				 BOOL searchBackwards)
 {
   NSUInteger i;
   NSUInteger length;
@@ -1183,54 +1183,54 @@ NSUInteger FindDelimiterInString(NSString * string,
   if (searchBackwards)
     {
       if (startLocation < 1000)
-        length = startLocation;
+	length = startLocation;
       else
-        length = 1000;
+	length = 1000;
 
       for (i=1; i <= length; i++)
-        {
-          unichar c;
+	{
+	  unichar c;
 
-          c = charAtIndex(string, sel, startLocation - i);
-          if (c == delimiter)
-            nesting--;
-          else if (c == oppositeDelimiter)
-            nesting++;
+	  c = charAtIndex(string, sel, startLocation - i);
+	  if (c == delimiter)
+	    nesting--;
+	  else if (c == oppositeDelimiter)
+	    nesting++;
 
-          if (nesting == 0)
-            break;
-        }
+	  if (nesting == 0)
+	    break;
+	}
 
       if (i > length)
-        return NSNotFound;
+	return NSNotFound;
       else
-        return startLocation - i;
+	return startLocation - i;
     }
   else
     {
       if ([string length] < startLocation + 1000)
-        length = [string length] - startLocation;
+	length = [string length] - startLocation;
       else
-        length = 1000;
+	length = 1000;
 
       for (i=1; i < length; i++)
-        {
-          unichar c;
+	{
+	  unichar c;
 
-          c = charAtIndex(string, sel, startLocation + i);
-          if (c == delimiter)
-            nesting--;
-          else if (c == oppositeDelimiter)
-            nesting++;
+	  c = charAtIndex(string, sel, startLocation + i);
+	  if (c == delimiter)
+	    nesting--;
+	  else if (c == oppositeDelimiter)
+	    nesting++;
 
-          if (nesting == 0)
-            break;
-        }
+	  if (nesting == 0)
+	    break;
+	}
 
       if (i == length)
-        return NSNotFound;
+	return NSNotFound;
       else
-        return startLocation + i;
+	return startLocation + i;
     }
 }
 
@@ -1254,39 +1254,39 @@ NSUInteger FindDelimiterInString(NSString * string,
 
       // restore the character's color and font attributes
       if (previousFont != nil)
-        {
-          [textStorage addAttribute:NSFontAttributeName
-                              value:previousFont
-                              range:r];
-        }
+	{
+	  [textStorage addAttribute:NSFontAttributeName
+			      value:previousFont
+			      range:r];
+	}
       else
-        {
-          [textStorage removeAttribute:NSFontAttributeName range:r];
-        }
+	{
+	  [textStorage removeAttribute:NSFontAttributeName range:r];
+	}
 
       if (previousFGColor != nil)
-        {
-          [textStorage addAttribute:NSForegroundColorAttributeName
-                              value:previousFGColor
-                              range:r];
-        }
+	{
+	  [textStorage addAttribute:NSForegroundColorAttributeName
+			      value:previousFGColor
+			      range:r];
+	}
       else
-        {
-          [textStorage removeAttribute:NSForegroundColorAttributeName
-                                 range:r];
-        }
+	{
+	  [textStorage removeAttribute:NSForegroundColorAttributeName
+				 range:r];
+	}
 
       if (previousBGColor != nil)
-        {
-          [textStorage addAttribute:NSBackgroundColorAttributeName
-                              value:previousBGColor
-                              range:r];
-        }
+	{
+	  [textStorage addAttribute:NSBackgroundColorAttributeName
+			      value:previousBGColor
+			      range:r];
+	}
       else
-        {
-          [textStorage removeAttribute:NSBackgroundColorAttributeName
-                                 range:r];
-        }
+	{
+	  [textStorage removeAttribute:NSBackgroundColorAttributeName
+				 range:r];
+	}
 
       highlited_chars[i] = -1;
     }
@@ -1318,29 +1318,29 @@ NSUInteger FindDelimiterInString(NSString * string,
 
       // store the previous character's attributes
       ASSIGN(previousFGColor,
-        [textStorage attribute:NSForegroundColorAttributeName
-                       atIndex:location
-                effectiveRange:&tmp]);
+	[textStorage attribute:NSForegroundColorAttributeName
+		       atIndex:location
+		effectiveRange:&tmp]);
       ASSIGN(previousBGColor,
-        [textStorage attribute:NSBackgroundColorAttributeName
-                       atIndex:location
-                effectiveRange:&tmp]);
+	[textStorage attribute:NSBackgroundColorAttributeName
+		       atIndex:location
+		effectiveRange:&tmp]);
       ASSIGN(previousFont, [textStorage attribute:NSFontAttributeName
-                                          atIndex:location
-                                   effectiveRange:&tmp]);
+					  atIndex:location
+				   effectiveRange:&tmp]);
 
       [textStorage addAttribute:NSFontAttributeName
-                          value:highlightFont
-                          range:r];
+			  value:highlightFont
+			  range:r];
       [textStorage addAttribute:NSBackgroundColorAttributeName
-                          value:highlightColor
-                          range:r];
+			  value:highlightColor
+			  range:r];
 /*      [textStorage addAttribute:NSForegroundColorAttributeName
-                          value:highlightColor
-                          range:r];
+			  value:highlightColor
+			  range:r];
 
       [textStorage removeAttribute:NSBackgroundColorAttributeName
-                             range:r];*/
+			     range:r];*/
 
       [textStorage endEditing];
     }
@@ -1378,24 +1378,23 @@ NSUInteger FindDelimiterInString(NSString * string,
       // or backward direction (depends on the kind of delimiter
       // we're searching for).
       if (CheckDelimiter(c, &oppositeDelimiter, &searchBackwards))
-        {
-          NSUInteger result;
+	{
+	  NSUInteger result;
 
-          result = FindDelimiterInString(myString,
-                                         oppositeDelimiter,
-                                         c,
-                                         selectedRange.location,
-                                         searchBackwards);
+	  result = FindDelimiterInString(myString,
+					 oppositeDelimiter,
+					 c,
+					 selectedRange.location,
+					 searchBackwards);
 
-          // and in case a delimiter is found, highlight it
-          if (result != NSNotFound)
-            {
-              [self highlightCharacterAt:selectedRange.location inEditor:editorView];
-              [self highlightCharacterAt:result inEditor:editorView];
-            }
-        }
+	  // and in case a delimiter is found, highlight it
+	  if (result != NSNotFound)
+	    {
+	      [self highlightCharacterAt:selectedRange.location inEditor:editorView];
+	      [self highlightCharacterAt:result inEditor:editorView];
+	    }
+	}
     }
 }
 
 @end
-

--- a/PCAppController.m
+++ b/PCAppController.m
@@ -1,7 +1,7 @@
 /*
    GNUstep ProjectCenter - http://www.gnustep.org/experience/ProjectCenter.html
 
-   Copyright (C) 2001-2013 Free Software Foundation
+   Copyright (C) 2001-2021 Free Software Foundation
 
    This file is part of GNUstep.
 
@@ -19,6 +19,7 @@
    License along with this library; if not, write to the Free
    Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 */
+
 #import <ProjectCenter/PCLogController.h>
 #import <ProjectCenter/PCFileManager.h>
 
@@ -48,7 +49,7 @@
   if ((self = [super init]))
     {
       infoController = [[PCInfoController alloc] init];
-      // Termporary workaround to initialize defaults values
+      // Temporary workaround to initialize defaults values
       prefController = [PCPrefController sharedPCPreferences];
       logController  = [PCLogController sharedLogController];
 
@@ -119,13 +120,13 @@
       || [[fileName pathExtension] isEqualToString:@"project"] == YES) 
     {
       [projectManager openProjectAt: fileName makeActive: YES];
-      [[[projectManager activeProject] projectWindow] 
-	makeKeyAndOrderFront:self];
     }
   else
     {
       [projectManager openFileAtPath:fileName];
     }
+
+  [[[projectManager activeProject] projectWindow] makeKeyAndOrderFront:self];
   
   return YES;
 }
@@ -136,8 +137,6 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-//  NSString *connectionName = [NSString stringWithFormat:@"ProjectCenter"];
-
   if ([prefController boolForKey:DisplayLog])
     {
       [logController showPanel];


### PR DESCRIPTION
…ossible...

* Modules/Editors/ProjectCenter/PCEditor.h
  Modules/Editors/ProjectCenter/PCEditor.m:
  - added the ivar modTime;
  - fixed a memleak in the -[openFileAtPath:editorManager:editable:]...
    the lvar 'attributes' was created but not released;
  - changed to keep track of the file's modification time... if the actual
    modificiation time during the call of -[saveFile] differs from
    the one kept in the 'modTime' then presents choices: 'Overwrite', 'Diff'
    and 'Cancel':
       - 'Overwrite' saves the PC's version of the file after making
         a backup copy with the extension .pcbackup;
       - 'Diff' creates a temporary copy .pc_unsaved of the PC's version
         and launches EasyDiff (if installed) for comparision... when
         EasyDiff is closed the copy is removed... it doesn't save
         the editor into the original file;
       - 'Cancel' is clear, no saving;