### PR TITLE
* forbid empty filename or filename with only whitespaces

### DIFF
--- a/Framework/PCFileNameField.m
+++ b/Framework/PCFileNameField.m
@@ -129,5 +129,17 @@ NSString *PCFileNameFieldNoFiles = @"No files selected";
   [super textDidEndEditing:aNotification];
 }
 
+- (BOOL)textShouldEndEditing:(NSText *)textObject
+{
+  NSString *text = [textObject string];
+  if ([text length] == 0 ||
+      [[text stringByTrimmingCharactersInSet:
+	      [NSCharacterSet whitespaceAndNewlineCharacterSet]] length] == 0)
+    {
+      return NO;
+    }
+
+  return YES;
+}
 @end
 


### PR DESCRIPTION
* Framework/PCFileNameField.m:
  - an empty filename or a filename with only whitespaces can lead
    to removing the origial file... added the own version of
    -[textShouldEndEditing:] to check the user input and forbid
    dangerous filenames;