### PR TITLE
* fixed an issue with gorm-file renaming

### DIFF
--- a/Framework/PCProject.m
+++ b/Framework/PCProject.m
@@ -1468,10 +1468,13 @@ NSString
 
       _editorCategory = [[_editor categoryPath] mutableCopy];
       range = [_editorCategory rangeOfString:fromFile];
-      [_editorCategory replaceCharactersInRange:range withString:toFile];
-      
-      [_editor setCategoryPath:_editorCategory];
-      [projectBrowser setPath:_editorCategory];
+      if (range.location != NSNotFound)
+	{
+	  [_editorCategory replaceCharactersInRange:range withString:toFile];
+
+	  [_editor setCategoryPath:_editorCategory];
+	  [projectBrowser setPath:_editorCategory];
+	}
       RELEASE(_editorCategory);
     }
   else

--- a/Framework/PCProjectEditor.m
+++ b/Framework/PCProjectEditor.m
@@ -218,6 +218,7 @@
   if (!editor)
     {
       NSLog(@"We don't have editor for file: %@", fileName);
+      [self setActiveEditor: nil];
       return nil;
     }
 


### PR DESCRIPTION
* Framework/PCProject.m:
  - renaming of a gorm file during another file' editor being active
    led to exception  (the case is because we don't have
    editors for gorm files so the last viewed file, not the renamed
    gorm, is present currently to the user)... the cause is not checking
    NSRange on NSNotFound (the active editor's path can have nothing
    common with the renamed path)... added required check to the
    -[renameFile:toFile:]... may be worth to reactivate any editor when
    a gorm file is selected;

* Framework/PCProjectEditor.m:
  - deactivate the active editor on a .gorm file selection;