### PR TITLE
* save just created projects to the list of recent documents

### DIFF
--- a/Framework/PCProjectManager.m
+++ b/Framework/PCProjectManager.m
@@ -817,7 +817,7 @@ NSString *PCActiveProjectDidChangeNotification = @"PCActiveProjectDidChange";
   NSString  *filePath;
   NSString  *projectType;
   PCProject *project;
-
+  NSString  *projectPath;
 
   [self createProjectTypeAccessaryView];
   
@@ -858,7 +858,9 @@ NSString *PCActiveProjectDidChangeNotification = @"PCActiveProjectDidChange";
 	  return;
 	}
 
-      [loadedProjects setObject:project forKey: [project projectPath]];
+      projectPath = [project projectPath];
+      [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:[NSURL fileURLWithPath:projectPath]];
+      [loadedProjects setObject:project forKey:projectPath];
       [self setActiveProject:project];
       [[project projectWindow] orderFront:self];
     }


### PR DESCRIPTION
A new just created project doesn't appear in the menu item for recently opened projects during the next invocation  of PC.
The PR fixes that.