### PR TITLE
Revert "Centered information panel."

### DIFF
--- a/PCInfoController.m
+++ b/PCInfoController.m
@@ -61,7 +61,7 @@
 //	PCLogError(self, @"error loading Menu NIB file!");
 	return;
     }
-  [infoWindow center];
+
   [infoWindow makeKeyAndOrderFront:self];
   [versionField setStringValue:[NSString stringWithFormat:@"Version %@", [infoDict objectForKey:@"ApplicationRelease"]]];
 		


### PR DESCRIPTION
Reverts gnustep/apps-projectcenter#20

As explained in the comments, this patch doesn't do the standard GNUstep behaviour as seen in other apps.