### PR TITLE
the ivar PCEditor->textColor is assigned in the unbalanced manner

### DIFF
--- a/Modules/Editors/ProjectCenter/PCEditor.m
+++ b/Modules/Editors/ProjectCenter/PCEditor.m
@@ -311,6 +311,7 @@
     }
 
   textColor = [prefs colorForKey:EditorForegroundColor defaultValue:textColor];
+  RETAIN(textColor);
 
   [attributes setObject:font forKey:NSFontAttributeName];
   [attributes setObject:textBackgroundColor forKey:NSBackgroundColorAttributeName];

--- a/Modules/Editors/ProjectCenter/PCEditor.m
+++ b/Modules/Editors/ProjectCenter/PCEditor.m
@@ -310,8 +310,7 @@
       textBackgroundColor = readOnlyColor;
     }
 
-  textColor = [prefs colorForKey:EditorForegroundColor defaultValue:textColor];
-  RETAIN(textColor);
+  ASSIGN(textColor, [prefs colorForKey:EditorForegroundColor defaultValue:textColor]);
 
   [attributes setObject:font forKey:NSFontAttributeName];
   [attributes setObject:textBackgroundColor forKey:NSBackgroundColorAttributeName];


### PR DESCRIPTION
I get the segmentation fault on exit when two files has been opened/edited during a session, e.g. a .m file (in the Classes) and .h file (in the Headers). I also does selections/highlighting here and there to surely reproduce the fault.

> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] --- Application WILL terminate
> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] PCPrefController: dealloc
> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] PCLogController: dealloc
> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] PCMenuController: dealloc
> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] PCProjectManager: dealloc
> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] PCFileManager: dealloc
> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] PCLoadedFilesPanel: dealloc
> 2021-11-29 09:25:45.028 ProjectCenter[59567:59567] --- Application WILL terminate.END
> 
> Program received signal SIGSEGV, Segmentation fault.
> 0x00007ffff6e31415 in objc_msg_lookup () from /usr/lib/x86_64-linux-gnu/libobjc.so.4
> (gdb) up
> #1  0x00007ffff2a21ed4 in -[PCEditor dealloc] (self=0x555555b2d7b0, _cmd=0x7ffff7476cd0 <_OBJC_SELECTOR_TABLE+48>) at PCEditor.m:257
> 257       RELEASE(textColor);
> (gdb) l
> 252       RELEASE(parserMethods);
> 253       RELEASE(aParser);
> 254
> 255       RELEASE(defaultFont);
> 256       RELEASE(highlightFont);
> 257       RELEASE(textColor);
> 258       RELEASE(backgroundColor);
> 259       RELEASE(readOnlyColor);
> 260
> 261       RELEASE(undoManager);
> (gdb)
> 

I found that the [PCEditor openFileAtPath:editorManager:editable:] does unbalanced assignment to the ivar 'textColor'.

* Modules/Editors/ProjectCenter/PCEditor.m:
  - changed the -[openFileAtPath:editorManager:editable:] to retain
    the ivar 'textColor'... to balance its retain/release count;

