### PR TITLE
fix opening files with absolute Path from builders error log output

### DIFF
--- a/Framework/PCProjectBuilder.m
+++ b/Framework/PCProjectBuilder.m
@@ -1145,9 +1145,16 @@
 	{// first message after "In file included from"
 //	  NSLog(@"Inlcuded File: %@", file);
 	  includedFile = [components objectAtIndex:0];
-      	  file = 
-	    [currentBuildPath stringByAppendingPathComponent:includedFile];
-	  currentEL = ELIncludedError;
+          if ([includedFile isAbsolutePath])
+            {
+              file = includedFile;
+            }
+          else
+            {
+      	      file = 
+	        [currentBuildPath stringByAppendingPathComponent:includedFile];
+	      currentEL = ELIncludedError;
+            }
 	}
       else
 	{


### PR DESCRIPTION
When there are files with absolute Paths in the PCProjectBuilder
error output, then the current buildPath is prepended, which is wrong.

Before prepending that, check if the file isAbsolutePath, and only prepend buildPath, when not.