### PR TITLE
sanitize uppercase filenames used in headers when adding new files to the project

### DIFF
--- a/Framework/PCFileCreator.m
+++ b/Framework/PCFileCreator.m
@@ -286,6 +286,29 @@ static NSDictionary  *dict = nil;
   return YES;
 }
 
+- (NSString *) sanitizeUppercaseFileNameString:(NSString *) input
+{
+    NSMutableString *sanitizedString = [NSMutableString stringWithCapacity:[input length]];
+    
+    // Create a character set that includes letters, digits, and the underscore character
+    NSMutableCharacterSet *allowedCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
+    [allowedCharacters addCharactersInString:@"_"];
+    
+    for (NSUInteger i = 0; i < [input length]; i++)
+      {
+        unichar character = [input characterAtIndex:i];
+        
+        if ([allowedCharacters characterIsMember:character])
+          {
+            [sanitizedString appendFormat:@"%C", character];
+          } else {
+            [sanitizedString appendString:@"_"];
+          }
+      }
+    
+    return sanitizedString;
+}
+
 - (void)replaceTagsInFileAtPath:(NSString *)newFile
                     withProject:(PCProject *)aProject
 {
@@ -296,6 +319,8 @@ static NSDictionary  *dict = nil;
   NSString *UCfn = [[aFile stringByDeletingPathExtension] uppercaseString];
   NSString *fn = [aFile stringByDeletingPathExtension];
   NSRange  subRange;
+
+  UCfn = [self sanitizeUppercaseFileNameString: UCfn];
 
 #ifdef WIN32 	 
   file = [[NSMutableString stringWithContentsOfFile: newFile 	 


### PR DESCRIPTION
For #define something in C, only alphanumeric and _ are allowed.

When creating a new file in the project, esp. headers, some ifdef dance is added, to prevent double inclusion. This take the file name literally.

For Categories, it's common to use NSSomeClass+Category as name, and that + sign breaks build.

Therefore sanitize the generated uppercase header file name, replace any non alphanumeric and _ with _ before replacing the string in the template.